### PR TITLE
Fixes invalid multibyte char (US-ASCII) errors

### DIFF
--- a/worm_scraper.rb
+++ b/worm_scraper.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'nokogiri'
 require 'open-uri'
 require 'uri'


### PR DESCRIPTION
Fixes:

    worm_scraper.rb:13: invalid multibyte char (US-ASCII)
    worm_scraper.rb:13: invalid multibyte char (US-ASCII)
    worm_scraper.rb:13: syntax error, unexpected $end, expecting ')'
      if @next_chapter.to_s.include?("½")

Ubuntu 14.04 LTS